### PR TITLE
Add tools for listing teams and states, and enhance issue resolution

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -6,6 +6,8 @@ import registerDelete from "./tools/linearDeleteIssue";
 import registerWebhooks from "./tools/linearWebhooks";
 import registerListIssues from "./tools/linearListIssues";
 import registerGetIssue from "./tools/linearGetIssue";
+import registerListTeams from "./tools/linearListTeams";
+import registerListStates from "./tools/linearListStates";
 
 export function registerTools(server: McpServer, env: Env): void {
 	registerCreate(server, env);
@@ -15,6 +17,8 @@ export function registerTools(server: McpServer, env: Env): void {
 	registerWebhooks(server, env);
 	registerListIssues(server, env);
 	registerGetIssue(server, env);
+	registerListTeams(server, env);
+	registerListStates(server, env);
 }
 
 

--- a/src/tools/linear.ts
+++ b/src/tools/linear.ts
@@ -1,8 +1,8 @@
-export async function linearFetch(
+export async function linearFetch<T = unknown>(
 	env: Env,
 	query: string,
 	variables?: Record<string, unknown>,
-) {
+): Promise<T> {
 	const res = await fetch(env.LINEAR_GRAPHQL_URL, {
 		method: "POST",
 		headers: {
@@ -11,9 +11,11 @@ export async function linearFetch(
 		},
 		body: JSON.stringify({ query, variables }),
 	});
-	const json = await res.json<any>();
+	const json = (await res.json()) as { data: T; errors?: unknown };
 	if (!res.ok || json.errors) {
-		throw new Error(`Linear ${res.status}: ${JSON.stringify(json.errors || json)}`);
+		throw new Error(
+			`Linear ${res.status}: ${JSON.stringify(json.errors || json)}`,
+		);
 	}
 	return json.data;
 }
@@ -23,15 +25,21 @@ export const GQL = {
 		query ($key: String!) { teams(filter: { key: { eq: $key } }) { nodes { id key name } } }`,
 	userByEmail: `
 		query ($email: String!) { users(filter: { email: { eq: $email } }) { nodes { id name email } } }`,
-	issueByIdOrKey: `
+	issueById: `
 		query ($id: String!) { issue(id: $id) { id team { id } } }`,
+	issueIdByTeamAndNumber: `
+		query ($teamId: ID!, $number: Float!) {
+			issues(
+				filter: { team: { id: { eq: $teamId } }, number: { eq: $number } }
+			) { nodes { id } }
+		}`,
 	teamWorkflowStates: `
-		query ($teamId: String!) { workflowStates(filter: { team: { id: { eq: $teamId } } }) { nodes { id name type } } }`,
+		query ($teamId: ID!) { workflowStates(filter: { team: { id: { eq: $teamId } } }) { nodes { id name type } } }`,
 	issuesByFilter: `
 		query (
-			$teamId: String, $assigneeId: String,
-			$updatedAfter: DateTime, $updatedBefore: DateTime,
-			$createdAfter: DateTime, $createdBefore: DateTime
+			$teamId: ID, $assigneeId: ID,
+			$updatedAfter: DateTimeOrDuration, $updatedBefore: DateTimeOrDuration,
+			$createdAfter: DateTimeOrDuration, $createdBefore: DateTimeOrDuration
 		) {
 			issues(
 				filter: {
@@ -61,6 +69,65 @@ export const GQL = {
 		}`,
 	webhookDelete: `mutation ($id: String!) { webhookDelete(id: $id) { success } }`,
 	teamIdByKey: `query ($key: String!) { teams(filter: { key: { eq: $key } }) { nodes { id } } }`,
+	teamsList: `query { teams(first: 50) { nodes { id key name } } }`,
 };
+
+export function isUuidLike(value: string): boolean {
+	return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/.test(
+		value,
+	);
+}
+
+function isIssueKey(value: string): boolean {
+	return /^[A-Z][A-Z0-9_]*-\d+$/.test(value);
+}
+
+function parseIssueKey(
+	key: string,
+): { teamKey: string; number: number } | null {
+	const m = key.match(/^([A-Z][A-Z0-9_]*)-(\d+)$/);
+	if (!m) return null;
+	return { teamKey: m[1], number: Number(m[2]) };
+}
+
+export async function resolveTeamIdFromKey(
+	env: Env,
+	teamKey: string,
+): Promise<string> {
+	const td = await linearFetch<{ teams: { nodes: Array<{ id: string }> } }>(
+		env,
+		GQL.teamByKey,
+		{ key: teamKey },
+	);
+	const teamId = td.teams.nodes[0]?.id as string | undefined;
+	if (!teamId) throw new Error(`Team no encontrado: ${teamKey}`);
+	return teamId;
+}
+
+export async function resolveIssueId(
+	env: Env,
+	idOrKey: string,
+): Promise<string> {
+	if (isUuidLike(idOrKey)) return idOrKey;
+	if (isIssueKey(idOrKey)) {
+		const parsed = parseIssueKey(idOrKey);
+		if (!parsed) throw new Error(`Formato de clave inválido: ${idOrKey}`);
+		const teamId = await resolveTeamIdFromKey(env, parsed.teamKey);
+		const d = await linearFetch<{ issues: { nodes: Array<{ id: string }> } }>(
+			env,
+			GQL.issueIdByTeamAndNumber,
+			{ teamId, number: parsed.number },
+		);
+		const id = d.issues?.nodes?.[0]?.id as string | undefined;
+		if (!id) throw new Error(`Issue no encontrado: ${idOrKey}`);
+		return id;
+	}
+	// Fallback: try as id; if not found, throw
+	const d = await linearFetch<{ issue?: { id?: string } }>(env, GQL.issueById, {
+		id: idOrKey,
+	});
+	if (!d.issue?.id) throw new Error(`Issue no encontrado: ${idOrKey}`);
+	return d.issue.id as string;
+}
 
 

--- a/src/tools/linearComment.ts
+++ b/src/tools/linearComment.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { linearFetch, GQL } from "./linear";
+import { linearFetch, GQL, resolveIssueId } from "./linear";
 
 export default function register(server: McpServer, env: Env) {
 	server.tool(
@@ -10,8 +10,9 @@ export default function register(server: McpServer, env: Env) {
 			body: z.string(),
 		},
 		async (input) => {
+			const issueId = await resolveIssueId(env, input.issueIdOrKey);
 			const r = await linearFetch(env, GQL.commentCreate, {
-				input: { issueId: input.issueIdOrKey, body: input.body },
+				input: { issueId, body: input.body },
 			});
 			return { content: [{ type: "text", text: `Comentario ${r.commentCreate?.comment?.id ?? "ok"}` }] };
 		},

--- a/src/tools/linearDeleteIssue.ts
+++ b/src/tools/linearDeleteIssue.ts
@@ -1,13 +1,14 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { linearFetch, GQL } from "./linear";
+import { linearFetch, GQL, resolveIssueId } from "./linear";
 
 export default function register(server: McpServer, env: Env) {
 	server.tool(
 		"linearDeleteIssue",
 		{ idOrKey: z.string() },
 		async (input) => {
-			await linearFetch(env, GQL.issueDelete, { id: input.idOrKey });
+			const id = await resolveIssueId(env, input.idOrKey);
+			await linearFetch(env, GQL.issueDelete, { id });
 			return { content: [{ type: "text", text: "Eliminado" }] };
 		},
 	);

--- a/src/tools/linearGetIssue.ts
+++ b/src/tools/linearGetIssue.ts
@@ -1,13 +1,14 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { linearFetch, GQL } from "./linear";
+import { linearFetch, GQL, resolveIssueId } from "./linear";
 
 export default function register(server: McpServer, env: Env) {
 	server.tool(
 		"linearGetIssue",
 		{ idOrKey: z.string() },
 		async (input) => {
-			const data = await linearFetch(env, GQL.issueByIdentifier, { id: input.idOrKey });
+			const id = await resolveIssueId(env, input.idOrKey);
+			const data = await linearFetch(env, GQL.issueByIdentifier, { id });
 			const i = data.issue;
 			if (!i) return { content: [{ type: "text", text: "Issue no encontrado" }] };
 			const text = `${i.identifier} ${i.title}\nEstado: ${i.state?.name ?? ""}\nAsignado: ${i.assignee?.name ?? ""}\nEquipo: ${i.team?.key ?? ""}\nActualizado: ${i.updatedAt}`;

--- a/src/tools/linearListIssues.ts
+++ b/src/tools/linearListIssues.ts
@@ -25,14 +25,22 @@ export default function register(server: McpServer, env: Env) {
 		async (input) => {
 			let teamId: string | undefined;
 			if (input.teamKey) {
-				const td = await linearFetch(env, GQL.teamByKey, { key: input.teamKey });
+				const td = await linearFetch<{ teams: { nodes: Array<{ id: string }> } }>(
+					env,
+					GQL.teamByKey,
+					{ key: input.teamKey },
+				);
 				teamId = td.teams.nodes[0]?.id;
 				if (!teamId) throw new Error(`Team no encontrado: ${input.teamKey}`);
 			}
 
 			let assigneeId: string | undefined;
 			if (input.assigneeEmail) {
-				const ud = await linearFetch(env, GQL.userByEmail, { email: input.assigneeEmail });
+				const ud = await linearFetch<{ users: { nodes: Array<{ id: string }> } }>(
+					env,
+					GQL.userByEmail,
+					{ email: input.assigneeEmail },
+				);
 				assigneeId = ud.users.nodes[0]?.id;
 				if (!assigneeId) throw new Error(`Usuario no encontrado: ${input.assigneeEmail}`);
 			}
@@ -55,7 +63,15 @@ export default function register(server: McpServer, env: Env) {
 			const toDateTime = (s?: string) => (s ? `${s}T00:00:00.000Z` : undefined);
 			const toDateTimeEnd = (s?: string) => (s ? `${s}T23:59:59.999Z` : undefined);
 
-			const data = await linearFetch(env, GQL.issuesByFilter, {
+			const data = await linearFetch<{
+				issues: {
+					nodes: Array<{
+						identifier: string;
+						title: string;
+						state?: { name?: string };
+					}>;
+				};
+			}>(env, GQL.issuesByFilter, {
 				teamId,
 				assigneeId,
 				createdAfter: toDateTime(createdAfter),
@@ -64,8 +80,9 @@ export default function register(server: McpServer, env: Env) {
 				updatedBefore: toDateTimeEnd(updatedBefore),
 			});
 
-			const items = (data.issues?.nodes || []).map((n: any) =>
-				`${n.identifier} ${n.title} [${n.state?.name ?? ""}]`);
+			const items = (data.issues?.nodes || []).map(
+				(n) => `${n.identifier} ${n.title} [${n.state?.name ?? ""}]`,
+			);
 			return { content: [{ type: "text", text: items.join("\n") || "Sin resultados" }] };
 		},
 	);
@@ -79,14 +96,22 @@ export default function register(server: McpServer, env: Env) {
 		async (input) => {
 			let teamId: string | undefined;
 			if (input.teamKey) {
-				const td = await linearFetch(env, GQL.teamByKey, { key: input.teamKey });
+				const td = await linearFetch<{ teams: { nodes: Array<{ id: string }> } }>(
+					env,
+					GQL.teamByKey,
+					{ key: input.teamKey },
+				);
 				teamId = td.teams.nodes[0]?.id;
 				if (!teamId) throw new Error(`Team no encontrado: ${input.teamKey}`);
 			}
 
 			let assigneeId: string | undefined;
 			if (input.assigneeEmail) {
-				const ud = await linearFetch(env, GQL.userByEmail, { email: input.assigneeEmail });
+				const ud = await linearFetch<{ users: { nodes: Array<{ id: string }> } }>(
+					env,
+					GQL.userByEmail,
+					{ email: input.assigneeEmail },
+				);
 				assigneeId = ud.users.nodes[0]?.id;
 				if (!assigneeId) throw new Error(`Usuario no encontrado: ${input.assigneeEmail}`);
 			}
@@ -94,14 +119,23 @@ export default function register(server: McpServer, env: Env) {
 			const today = isoDate(new Date());
 			const toDateTime = (s: string) => `${s}T00:00:00.000Z`;
 			const toDateTimeEnd = (s: string) => `${s}T23:59:59.999Z`;
-			const data = await linearFetch(env, GQL.issuesByFilter, {
+			const data = await linearFetch<{
+				issues: {
+					nodes: Array<{
+						identifier: string;
+						title: string;
+						state?: { name?: string };
+					}>;
+				};
+			}>(env, GQL.issuesByFilter, {
 				teamId,
 				assigneeId,
 				updatedAfter: toDateTime(today),
 				updatedBefore: toDateTimeEnd(today),
 			});
-			const items = (data.issues?.nodes || []).map((n: any) =>
-				`${n.identifier} ${n.title} [${n.state?.name ?? ""}]`);
+			const items = (data.issues?.nodes || []).map(
+				(n) => `${n.identifier} ${n.title} [${n.state?.name ?? ""}]`,
+			);
 			return { content: [{ type: "text", text: items.join("\n") || "Sin resultados" }] };
 		},
 	);

--- a/src/tools/linearListStates.ts
+++ b/src/tools/linearListStates.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { GQL, linearFetch, resolveTeamIdFromKey } from "./linear";
+
+export default function register(server: McpServer, env: Env) {
+	server.tool(
+		"linearListStates",
+		{ teamKey: z.string() },
+		async (input) => {
+			const teamId = await resolveTeamIdFromKey(env, input.teamKey);
+			const data = await linearFetch<{ workflowStates: { nodes: Array<{ id: string; name: string; type?: string }> } }>(
+				env,
+				GQL.teamWorkflowStates,
+				{ teamId },
+			);
+			const items = (data.workflowStates?.nodes || []).map(
+				(s) => `${s.id}\t${s.name}\t${s.type ?? ""}`,
+			);
+			return { content: [{ type: "text", text: items.join("\n") || "Sin estados" }] };
+		},
+	);
+}
+
+

--- a/src/tools/linearListTeams.ts
+++ b/src/tools/linearListTeams.ts
@@ -1,0 +1,20 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { GQL, linearFetch } from "./linear";
+
+export default function register(server: McpServer, env: Env) {
+	server.tool(
+		"linearListTeams",
+		{},
+		async () => {
+			const data = await linearFetch<{ teams: { nodes: Array<{ id: string; key: string; name: string }> } }>(
+				env,
+				GQL.teamsList,
+				{},
+			);
+			const items = (data.teams?.nodes || []).map((t) => `${t.key}\t${t.name}`);
+			return { content: [{ type: "text", text: items.join("\n") || "Sin equipos" }] };
+		},
+	);
+}
+
+


### PR DESCRIPTION
- Introduced `linearListTeams` and `linearListStates` tools for fetching teams and workflow states.
- Updated existing tools to utilize `resolveIssueId` and `resolveTeamIdFromKey` for improved issue and team identification.
- Enhanced type safety in GraphQL fetch calls across various tools.
- Refactored issue-related tools to streamline ID resolution and error handling.